### PR TITLE
Remove rez bind --quickstart mention from docs

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
         with:
           results_file: results.sarif
           results_format: sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -61,6 +61,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3.29.0
         with:
           sarif_file: results.sarif

--- a/docs/source/configuring_rez.rst
+++ b/docs/source/configuring_rez.rst
@@ -11,7 +11,7 @@ Settings are determined in the following way:
 - The setting is then overridden if it is present in another settings file pointed at by the
   :envvar:`REZ_CONFIG_FILE` environment variable. This can also be a path-like variable, to read from
   multiple configuration files;
-- The setting is further overriden if it is present in ``$HOME/.rezconfig``;
+- The setting is further overriden if it is present in ``$HOME/.rezconfig`` or ``$HOME/.rezconfig.py``;
 - The setting is overridden again if the environment variable :envvar:`REZ_XXX` is present, where ``XXX`` is
   the uppercase version of the setting key. For example, :data:`.image_viewer` will be overriden by
   :envvar:`REZ_IMAGE_VIEWER`.
@@ -29,7 +29,7 @@ variable :envvar:`REZ_CONFIG_FILE` is then set to for all your users.
 Supported Configuration File Formats
 ====================================
 
-Rez supports both YAML configuration files and Python configuration files.
+Rez supports both YAML configuration files (``.rezconfig``) and Python configuration files (``.rezconfig.py``).
 
 You may prefer a Python based configuration file if you need to vary your configuration settings based on your
 current platform.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -7,17 +7,20 @@ Essential packages
 
 .. warning::
    :ref:`rez-bind` is going to be deprecated. The current implementation is not actively maintained.
+   .. TODO - Remove reference to rez-bind --quickstart
    Especially on windows, using :option:`--quickstart <rez-bind --quickstart>` is likely to fail.
 
    Even if rez-bind will be deprecated and we generally discourage its use, you can safely use it for creating the ``arch``, ``os`` and ``platform`` packages.
 
 After installation, you need to create some essential Rez packages. The :ref:`rez-bind`
 tool creates Rez packages that reference software already installed on your system.
+.. TODO - Remove reference to rez-bind --quickstart
 Use the :option:`--quickstart <rez-bind --quickstart>` argument to bind a set of standard packages:
 
 .. note::
    You may require administrative privileges for some of them
 
+.. TODO - Remove reference to rez-bind --quickstart
 .. code-block:: text
 
    ]$ rez-bind --quickstart

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -7,8 +7,7 @@ Essential packages
 
 .. warning::
    :ref:`rez-bind` is going to be deprecated. The current implementation is not actively maintained.
-   Even if rez-bind will be deprecated and we generally discourage its use, 
-   you can safely use it for creating the ``arch``, ``os`` and ``platform`` packages.
+   Even if rez-bind will be deprecated and we generally discourage its use, you can safely use it for creating the ``arch``, ``os`` and ``platform`` packages.
 
 After installation, you need to create some essential Rez packages. The :ref:`rez-bind`
 tool creates Rez packages that reference software already installed on your system.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -7,7 +7,8 @@ Essential packages
 
 .. warning::
    :ref:`rez-bind` is going to be deprecated. The current implementation is not actively maintained.
-   However, you can safely use it for creating the essential ``arch``, ``os`` and ``platform`` packages.
+   Even if rez-bind will be deprecated and we generally discourage its use, 
+   you can safely use it for creating the ``arch``, ``os`` and ``platform`` packages.
 
 After installation, you need to create some essential Rez packages. The :ref:`rez-bind`
 tool creates Rez packages that reference software already installed on your system.
@@ -62,7 +63,7 @@ You may also want to bind additional packages for your development environment. 
    ]$ rez-bind pip         # Python package installer
    Binding pip into /home/ajohns/packages...
 
-   Successfully converted the following essential software found on the current system into Rez packages:
+   Successfully converted the following software found on the current system into Rez packages:
 
    PACKAGE     URI
    -------     ---

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -7,44 +7,70 @@ Essential packages
 
 .. warning::
    :ref:`rez-bind` is going to be deprecated. The current implementation is not actively maintained.
-   .. TODO - Remove reference to rez-bind --quickstart
-   Especially on windows, using :option:`--quickstart <rez-bind --quickstart>` is likely to fail.
-
-   Even if rez-bind will be deprecated and we generally discourage its use, you can safely use it for creating the ``arch``, ``os`` and ``platform`` packages.
+   However, you can safely use it for creating the essential ``arch``, ``os`` and ``platform`` packages.
 
 After installation, you need to create some essential Rez packages. The :ref:`rez-bind`
 tool creates Rez packages that reference software already installed on your system.
-.. TODO - Remove reference to rez-bind --quickstart
-Use the :option:`--quickstart <rez-bind --quickstart>` argument to bind a set of standard packages:
+
+Create the essential system packages by running these individual commands:
 
 .. note::
    You may require administrative privileges for some of them
 
-.. TODO - Remove reference to rez-bind --quickstart
 .. code-block:: text
 
-   ]$ rez-bind --quickstart
-   Binding platform into /home/ajohns/packages...
+   ]$ rez-bind arch
    Binding arch into /home/ajohns/packages...
+   
+   ]$ rez-bind os
    Binding os into /home/ajohns/packages...
-   Binding python into /home/ajohns/packages...
-   Binding rez into /home/ajohns/packages...
-   Binding rezgui into /home/ajohns/packages...
-   Binding setuptools into /home/ajohns/packages...
-   Binding pip into /home/ajohns/packages...
+   
+   ]$ rez-bind platform
+   Binding platform into /home/ajohns/packages...
 
-   Successfully converted the following software found on the current system into Rez packages:
+   Successfully converted the following essential software found on the current system into Rez packages:
 
    PACKAGE     URI
    -------     ---
    arch        /home/ajohns/packages/arch/x86_64/package.py
    os          /home/ajohns/packages/os/osx-10.11.5/package.py
-   pip         /home/ajohns/packages/pip/8.0.2/package.py
    platform    /home/ajohns/packages/platform/osx/package.py
+
+Optional packages
+-----------------
+
+You may also want to bind additional packages for your development environment. These can be bound individually as needed:
+
+.. note::
+   These optional packages may be less reliable, especially on Windows. Consider creating 
+   custom package definitions instead if you encounter issues.
+
+.. code-block:: text
+
+   ]$ rez-bind python      # Python interpreter
+   Binding python into /home/ajohns/packages...
+   
+   ]$ rez-bind rez         # Rez itself 
+   Binding rez into /home/ajohns/packages...
+   
+   ]$ rez-bind rezgui      # Rez GUI tools
+   Binding rezgui into /home/ajohns/packages...
+   
+   ]$ rez-bind setuptools  # Python setuptools
+   Binding setuptools into /home/ajohns/packages...
+   
+   ]$ rez-bind pip         # Python package installer
+   Binding pip into /home/ajohns/packages...
+
+   Successfully converted the following essential software found on the current system into Rez packages:
+
+   PACKAGE     URI
+   -------     ---
    python      /home/ajohns/packages/python/2.7.11/package.py
    rez         /home/ajohns/packages/rez/2.0.rc1.44/package.py
    rezgui      /home/ajohns/packages/rezgui/2.0.rc1.44/package.py
    setuptools  /home/ajohns/packages/setuptools/19.4/package.py
+   pip         /home/ajohns/packages/pip/8.0.2/package.py
 
 Now you should be able to create an environment containing Python. Try this:
 

--- a/src/rez/bind/_utils.py
+++ b/src/rez/bind/_utils.py
@@ -26,8 +26,7 @@ def log(msg):
 
 def make_dirs(*dirs):
     path = os.path.join(*dirs)
-    if not os.path.exists(path):
-        os.makedirs(path)
+    os.makedirs(path, exist_ok=True)
     return path
 
 

--- a/src/rez/package_cache.py
+++ b/src/rez/package_cache.py
@@ -24,8 +24,7 @@ from rez.config import config
 from rez.exceptions import PackageCacheError
 from rez.vendor.lockfile import LockFile, NotLocked
 from rez.vendor.progress.spinner import PixelSpinner
-from rez.utils.filesystem import safe_listdir, safe_makedirs, safe_remove, \
-    forceful_rmtree
+from rez.utils.filesystem import forceful_rmtree, safe_listdir, safe_remove
 from rez.utils.colorize import ColorizedStreamHandler
 from rez.utils.logging_ import print_warning
 from rez.packages import get_variant
@@ -100,9 +99,9 @@ class PackageCache(object):
         self.path = path
 
         # make dirs for internal use
-        safe_makedirs(self._log_dir)
-        safe_makedirs(self._pending_dir)
-        safe_makedirs(self._remove_dir)
+        os.makedirs(self._log_dir, exist_ok=True)
+        os.makedirs(self._pending_dir, exist_ok=True)
+        os.makedirs(self._remove_dir, exist_ok=True)
 
     def get_cached_root(self, variant):
         """Get location of variant payload copy.
@@ -172,7 +171,6 @@ class PackageCache(object):
             - int: One of VARIANT_FOUND, VARIANT_CREATED, VARIANT_COPYING, VARIANT_COPY_STALLED
         """
         from rez.utils.base26 import get_next_base26
-        from rez.utils.filesystem import safe_makedirs
 
         # do some sanity checking on variant to cache
         package = variant.parent
@@ -263,7 +261,7 @@ class PackageCache(object):
 
         # 1.
         path = self._get_hash_path(variant)
-        safe_makedirs(path)
+        os.makedirs(path, exist_ok=True)
 
         # construct data to store to json file
         data = {

--- a/src/rez/package_copy.py
+++ b/src/rez/package_copy.py
@@ -17,7 +17,7 @@ from rez.utils.base26 import create_unique_base26_symlink
 from rez.utils.sourcecode import IncludeModuleManager
 from rez.utils.logging_ import print_info, print_warning
 from rez.utils.filesystem import replacing_symlink, replacing_copy, \
-    safe_makedirs, additive_copytree, make_path_writable, get_existing_path
+    additive_copytree, make_path_writable, get_existing_path
 
 
 def copy_package(package, dest_repository, variants=None, shallow=False,
@@ -287,7 +287,7 @@ def _copy_variant_payload(src_variant, dest_pkg_repo, shallow=False,
 
     # copy the variant payload
     with ctxt:
-        safe_makedirs(variant_install_path)
+        os.makedirs(variant_install_path, exist_ok=True)
 
         # determine files not to copy
         skip_files = []
@@ -362,7 +362,7 @@ def _copy_variant_payload(src_variant, dest_pkg_repo, shallow=False,
                 src_package.config.variant_shortlinks_dirname
             )
 
-            safe_makedirs(base_shortlinks_path)
+            os.makedirs(base_shortlinks_path, exist_ok=True)
 
             # shortlink
             rel_variant_path = os.path.relpath(
@@ -425,5 +425,5 @@ def _copy_package_include_modules(src_package, dest_pkg_repo, overrides=None):
         ctxt = with_noop()
 
     with ctxt:
-        safe_makedirs(dest_include_modules_path)
+        os.makedirs(dest_include_modules_path, exist_ok=True)
         additive_copytree(src_include_modules_path, dest_include_modules_path)

--- a/src/rez/package_maker.py
+++ b/src/rez/package_maker.py
@@ -220,15 +220,13 @@ def make_package(name, path, make_base=None, make_root=None, skip_existing=True,
 
             base = variant_.base
             if make_base and base:
-                if not os.path.exists(base):
-                    os.makedirs(base)
+                os.makedirs(base, exist_ok=True)
                 os.chdir(base)
                 make_base(variant_, base)
 
             root = variant_.root
             if make_root and root:
-                if not os.path.exists(root):
-                    os.makedirs(root)
+                os.makedirs(root, exist_ok=True)
                 os.chdir(root)
                 make_root(variant_, root)
 

--- a/src/rez/package_test.py
+++ b/src/rez/package_test.py
@@ -213,6 +213,12 @@ class PackageTestRunner(object):
         run_on = ["default"] if not requested_tests else None
         pkg_test_names = self.get_test_names(run_on=run_on)
         requested_test_names = set()
+
+        if not requested_tests:
+            # if no tests are explicitly specified, then return all tests
+            # found in the package
+            return pkg_test_names
+
         for requested_test in requested_tests:
             requested_test_names.update(set(fnmatch.filter(pkg_test_names, requested_test)))
         return requested_test_names

--- a/src/rez/pip.py
+++ b/src/rez/pip.py
@@ -386,8 +386,7 @@ def pip_install_package(source_name, pip_version=None, python_version=None,
                 src = os.path.join(targetpath, rel_src)
                 dest = os.path.join(path, rel_dest)
 
-                if not os.path.exists(os.path.dirname(dest)):
-                    os.makedirs(os.path.dirname(dest))
+                os.makedirs(os.path.dirname(dest), exist_ok=True)
 
                 shutil.copyfile(src, dest)
 

--- a/src/rez/resolved_context.py
+++ b/src/rez/resolved_context.py
@@ -1697,7 +1697,7 @@ class ResolvedContext(object):
 
         data = d.get("package_orderers")
         if data:
-            r.package_orderers = [package_order.from_pod(x) for x in data]
+            r.package_orderers = PackageOrderList([package_order.from_pod(x) for x in data])
         else:
             r.package_orderers = None
 

--- a/src/rez/suite.py
+++ b/src/rez/suite.py
@@ -441,7 +441,7 @@ class Suite(object):
                 raise SuiteError("Cannot save, path exists: %r" % path)
 
         contexts_path = os.path.join(path, "contexts")
-        os.makedirs(contexts_path)
+        os.makedirs(contexts_path, exist_ok=True)
 
         # write suite data
         data = self.to_dict()
@@ -460,7 +460,7 @@ class Suite(object):
 
         # create alias wrappers
         tools_path = os.path.join(path, "bin")
-        os.makedirs(tools_path)
+        os.makedirs(tools_path, exist_ok=True)
         if verbose:
             print("creating alias wrappers in %r..." % tools_path)
 

--- a/src/rez/tests/test_context.py
+++ b/src/rez/tests/test_context.py
@@ -278,6 +278,35 @@ class TestContext(TestBase, TempdirMixin):
         resolved = [x.qualified_package_name for x in r.resolved_packages]
         self.assertEqual(resolved, ['python-2.7.0'])
 
+    def test_serialize_roundtrip_with_extra_settings(self):
+        from rez.package_order import VersionSplitPackageOrder
+        from rez.version import Version
+
+        packages_path = self.data_path("solver", "packages")
+
+        file = os.path.join(self.root, "roundtrip.rxt")
+        orderers = [VersionSplitPackageOrder(Version("2.6.8"))]
+        r1 = ResolvedContext(
+            ["python"],
+            package_orderers=orderers,
+            package_paths=[packages_path],
+        )
+        r1.save(file)
+        r2 = ResolvedContext.load(file)
+
+        self.assertEqual(r1, r2)
+
+        ignored_properties = [
+            'load_path',
+            'graph_string',
+            'graph_'
+        ]
+        for k, v in r1.__dict__.items():
+            if k in ignored_properties:
+                continue
+            # check types here, as not all type instances are comparable
+            self.assertIs(type(v), type(r2.__dict__.get(k)))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/rez/tests/test_package_repository.py
+++ b/src/rez/tests/test_package_repository.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Rez Project
+
+
+"""
+Test package repository plugin.
+"""
+import unittest
+
+from rezplugins.package_repository import filesystem
+from rez.packages import create_package
+from rez.tests.util import TestBase, TempdirMixin
+from rez.utils.platform_ import platform_
+
+
+class TestFilesystemPackageRepository(TestBase, TempdirMixin):
+    @classmethod
+    def setUpClass(cls):
+        TempdirMixin.setUpClass()
+
+        cls.settings = dict()
+
+    @classmethod
+    def tearDownClass(cls):
+        TempdirMixin.tearDownClass()
+
+    @unittest.skipIf(platform_.name != "windows",
+                     "Skipping because this issue only affects case-insensitive platforms.")
+    def test_mismatching_case(self):
+        """Test that we get a caught PackageRepositoryError on case-insensitive platforms."""
+        pool = filesystem.ResourcePool(cache_size=None)
+        pkg_repository = filesystem.FileSystemPackageRepository(self.root, pool)
+
+        package = create_package("myTestPackage", data={})
+        variant = next(package.iter_variants())
+        case_mismatch_package = create_package("MyTestPackage", data={})
+        case_mismatch_variant = next(case_mismatch_package.iter_variants())
+
+        pkg_repository._create_variant(variant, overrides={})
+        with self.assertRaises(filesystem.PackageRepositoryError):
+            pkg_repository._create_variant(case_mismatch_variant, overrides={})

--- a/src/rez/tests/test_packages.py
+++ b/src/rez/tests/test_packages.py
@@ -347,8 +347,7 @@ class TestPackages(TestBase, TempdirMixin):
     def test_variant_install(self):
         """test variant installation."""
         repo_path = os.path.join(self.root, "packages")
-        if not os.path.exists(repo_path):
-            os.makedirs(repo_path)
+        os.makedirs(repo_path, exist_ok=True)
 
         def _data(obj):
             d = obj.validated_data()

--- a/src/rez/tests/test_test.py
+++ b/src/rez/tests/test_test.py
@@ -264,3 +264,46 @@ class TestTest(TestBase, TempdirMixin):
             "failed",
             "move_meeting_to_noon did not fail",
         )
+
+    def test_empty_test_list(self):
+        """
+        package.py unit tests are correctly found when no test name is provided (empty list)
+        """
+        self.inject_python_repo()
+        context = ResolvedContext(["testing_obj", "python"])
+        # This will get us more code coverage :)
+        self.inject_python_repo()
+        runner = PackageTestRunner(
+            package_request="testing_obj",
+            package_paths=context.package_paths,
+
+        )
+
+        test_names = runner.find_requested_test_names([])
+        self.assertEqual(4, len(test_names))
+
+        for test_name in test_names:
+            runner.run_test(test_name)
+
+        self.assertEqual(runner.test_results.num_tests, 4)
+
+        self.assertEqual(
+            self._get_test_result(runner, "check_car_ideas")["status"],
+            "success",
+            "check_car_ideas did not succeed",
+        )
+        self.assertEqual(
+            self._get_test_result(runner, "move_meeting_to_noon")["status"],
+            "failed",
+            "move_meeting_to_noon did not fail",
+        )
+        self.assertEqual(
+            self._get_test_result(runner, "command_as_string_success")["status"],
+            "success",
+            "command_as_string_success did not succeed",
+        )
+        self.assertEqual(
+            self._get_test_result(runner, "command_as_string_fail")["status"],
+            "failed",
+            "command_as_string_fail did not fail",
+        )

--- a/src/rez/tests/test_util.py
+++ b/src/rez/tests/test_util.py
@@ -6,13 +6,22 @@
 unit tests for 'util' module
 """
 import os
-import tempfile
 import sys
-from rez.tests.util import TestBase
+from rez.tests.util import TestBase, TempdirMixin
 from rez.util import load_module_from_file
 
 
-class TestLoadModuleFromFile(TestBase):
+class TestLoadModuleFromFile(TestBase, TempdirMixin):
+    @classmethod
+    def setUpClass(cls):
+        TempdirMixin.setUpClass()
+
+        cls.settings = dict()
+
+    @classmethod
+    def tearDownClass(cls):
+        TempdirMixin.tearDownClass()
+
     def test_load_module(self):
         """Ensure that the imported module does not show up in sys.modules"""
         # Random chars are used in the module name to ensure that the module name is unique
@@ -21,10 +30,9 @@ class TestLoadModuleFromFile(TestBase):
         module = 'utils_test_7cd3a335'
 
         filename = '{0}.py'.format(module)
-        tmpdir = tempfile.mkdtemp(prefix="rez_selftest_")
 
-        with open(os.path.join(tmpdir, filename), 'w') as fd:
+        with open(os.path.join(self.root, filename), 'w') as fd:
             fd.write('')
 
-        load_module_from_file(module, os.path.join(tmpdir, filename))
+        load_module_from_file(module, os.path.join(self.root, filename))
         self.assertEqual(sys.modules.get(module), None, msg='Module was found in sys.modules')

--- a/src/rez/utils/filesystem.py
+++ b/src/rez/utils/filesystem.py
@@ -173,19 +173,6 @@ def safe_listdir(path):
         raise
 
 
-def safe_makedirs(path):
-    """Safe makedirs.
-
-    Works in a multithreaded scenario.
-    """
-    if not os.path.exists(path):
-        try:
-            os.makedirs(path)
-        except OSError:
-            if not os.path.exists(path):
-                raise
-
-
 def safe_remove(path):
     """Safely remove the given file or directory.
 
@@ -303,8 +290,7 @@ def replace_file_or_dir(dest, source):
 def additive_copytree(src, dst, symlinks=False, ignore=None):
     """Version of `copytree` that merges into an existing directory.
     """
-    if not os.path.exists(dst):
-        os.makedirs(dst)
+    os.makedirs(dst, exist_ok=True)
 
     for item in os.listdir(src):
         s = os.path.join(src, item)
@@ -437,8 +423,7 @@ def copytree(src, dst, symlinks=False, ignore=None, hardlinks=False):
     else:
         copy = shutil.copy2
 
-    if not os.path.isdir(dst):
-        os.makedirs(dst)
+    os.makedirs(dst, exist_ok=True)
 
     errors = []
     for name in names:

--- a/src/rez/utils/py_dist.py
+++ b/src/rez/utils/py_dist.py
@@ -16,8 +16,7 @@ import textwrap
 
 def _mkdirs(*dirs):
     path = os.path.join(*dirs)
-    if not os.path.exists(path):
-        os.makedirs(path)
+    os.makedirs(path, exist_ok=True)
     return path
 
 

--- a/src/rezplugins/build_process/local.py
+++ b/src/rezplugins/build_process/local.py
@@ -14,8 +14,8 @@ from rez.utils import with_noop
 from rez.utils.logging_ import print_warning
 from rez.utils.base26 import create_unique_base26_symlink
 from rez.utils.colorize import Printer, warning
-from rez.utils.filesystem import safe_makedirs, copy_or_replace, \
-    make_path_writable, get_existing_path, forceful_rmtree
+from rez.utils.filesystem import copy_or_replace, get_existing_path, \
+    forceful_rmtree, make_path_writable
 from rez.utils.sourcecode import IncludeModuleManager
 from rez.utils.filesystem import TempDirs
 from rez.package_test import PackageTestRunner, PackageTestResults
@@ -148,7 +148,7 @@ class LocalBuildProcess(BuildProcessHelper):
         if clean and os.path.exists(variant_build_path):
             self._rmtree(variant_build_path)
 
-        safe_makedirs(variant_build_path)
+        os.makedirs(variant_build_path, exist_ok=True)
 
         # find last dir of installation path that exists, and possibly make it
         # writable during variant installation
@@ -167,8 +167,7 @@ class LocalBuildProcess(BuildProcessHelper):
                 pkg_repo = package_repository_manager.get_repository(install_path)
                 pkg_repo.pre_variant_install(variant.resource)
 
-                if not os.path.exists(variant_install_path):
-                    safe_makedirs(variant_install_path)
+                os.makedirs(variant_install_path, exist_ok=True)
 
                 # if hashed variants are enabled, create the variant shortlink
                 if variant.parent.hashed_variants:
@@ -179,7 +178,7 @@ class LocalBuildProcess(BuildProcessHelper):
                             variant.parent.config.variant_shortlinks_dirname
                         )
 
-                        safe_makedirs(base_shortlinks_path)
+                        os.makedirs(base_shortlinks_path, exist_ok=True)
 
                         # create the shortlink
                         rel_variant_path = os.path.relpath(
@@ -293,7 +292,7 @@ class LocalBuildProcess(BuildProcessHelper):
         base_path = self.get_package_install_path(install_path)
 
         path = os.path.join(base_path, IncludeModuleManager.include_modules_subpath)
-        safe_makedirs(path)
+        os.makedirs(path, exist_ok=True)
 
         definition_python_path = self.package.config.package_definition_python_path
 

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -10,7 +10,6 @@ from functools import lru_cache
 import os.path
 import os
 import stat
-import errno
 import time
 import shutil
 
@@ -677,10 +676,7 @@ class FileSystemPackageRepository(PackageRepository):
             return 0
 
         # create .ignore{ver} file
-        try:
-            os.makedirs(fam_path)
-        except OSError:  # already exists
-            pass
+        os.makedirs(fam_path, exist_ok=True)
 
         with open(filepath, 'w'):
             pass
@@ -861,8 +857,7 @@ class FileSystemPackageRepository(PackageRepository):
         path = self.location
 
         family_path = os.path.join(path, variant_resource.name)
-        if not os.path.isdir(family_path):
-            os.makedirs(family_path)
+        os.makedirs(family_path, exist_ok=True)
 
         filename = self.building_prefix + str(variant_resource.version)
         filepath = os.path.join(family_path, filename)
@@ -931,13 +926,12 @@ class FileSystemPackageRepository(PackageRepository):
         path = self.location
 
         try:
-            os.makedirs(path)
+            os.makedirs(path, exist_ok=True)
         except OSError as e:
-            if e.errno != errno.EEXIST:
-                raise PackageRepositoryError(
-                    "Package repository path %r could not be created: %s: %s"
-                    % (path, e.__class__.__name__, e)
-                )
+            raise PackageRepositoryError(
+                "Package repository path %r could not be created: %s: %s"
+                % (path, e.__class__.__name__, e)
+            )
 
         # install the variant
         def _create_variant():
@@ -1194,8 +1188,7 @@ class FileSystemPackageRepository(PackageRepository):
 
     def _create_family(self, name):
         path = os.path.join(self.location, name)
-        if not os.path.exists(path):
-            os.makedirs(path)
+        os.makedirs(path, exist_ok=True)
 
         self._on_changed(name)
         return self.get_package_family(name)
@@ -1397,8 +1390,7 @@ class FileSystemPackageRepository(PackageRepository):
             pkg_base_path = os.path.join(family_path, str(variant_version))
         else:
             pkg_base_path = family_path
-        if not os.path.exists(pkg_base_path):
-            os.makedirs(pkg_base_path)
+        os.makedirs(pkg_base_path, exist_ok=True)
 
         # Apply overrides.
         #

--- a/src/rezplugins/package_repository/filesystem.py
+++ b/src/rezplugins/package_repository/filesystem.py
@@ -1206,6 +1206,11 @@ class FileSystemPackageRepository(PackageRepository):
         family = self.get_package_family(variant_name)
         if not family:
             family = self._create_family(variant_name)
+            if not family:
+                raise PackageRepositoryError(
+                    f'Package family: {variant_name} does not exist and could not be created '
+                    f'in repository: {self.location}. Perhaps family already exists with different character case?'
+                )
 
         if isinstance(family, FileSystemCombinedPackageFamilyResource):
             raise NotImplementedError(


### PR DESCRIPTION
### Changes Made
The PR contains three focused commits that systematically improve the documentation:

1. Mark quickstart references for removal (f5c396bc): Added TODO comments to identify all instances of --quickstart references that needed to be removed.

2. Replace quickstart with individual commands (5e69b94d):

- Removed all references to rez-bind --quickstart
- Replaced with individual rez-bind commands for essential packages (arch, os, platform)
- Split package binding into two sections: "Essential packages" (safe to use) and "Optional packages" (less reliable)
- Added appropriate warnings about potential issues with optional packages, especially on Windows

3. Fix warning text formatting (f129b1e8): Restored proper formatting and wording in the deprecation warning for rez-bind.